### PR TITLE
Fix pca transformation and test for single point

### DIFF
--- a/eulerpi/core/data_transformation.py
+++ b/eulerpi/core/data_transformation.py
@@ -209,9 +209,15 @@ class DataPCA(DataTransformation):
         Returns:
             jnp.ndarray: The data projected onto and expressed in the basis of the principal components.
         """
-        return self.pca.transform(data.reshape(-1, data.shape[-1])).reshape(
+        result = self.pca.transform(data.reshape(-1, data.shape[-1])).reshape(
             -1, self.pca.n_components_
         )
+
+        # if the input data was 1D, the output should be 1D as well
+        if data.ndim == 1:
+            result = result.flatten()
+
+        return result
 
     def jacobian(self, data: jnp.ndarray) -> jnp.ndarray:
         """Return the jacobian of the pca transformation at the given data point(s).

--- a/tests/test_data_transformation.py
+++ b/tests/test_data_transformation.py
@@ -43,21 +43,21 @@ def test_DataNormalizer():
 def test_DataPCA():
     """Test whether the DataPCA transformation is able to run on data with different dimensions."""
     n_samples = 100
-    data1d = np.random.rand(n_samples, 1)
-    data2d = np.random.rand(n_samples, 2)
-    test_data = [(1, 1, data1d), (2, 2, data2d), (2, 1, data2d)]
+    data1 = np.random.rand(n_samples, 1)
+    data2 = np.random.rand(n_samples, 2)
+    data3 = np.random.rand(n_samples, 3)
+    test_data = [(1, 1, data1), (2, 2, data2), (2, 1, data2), (3, 2, data3)]
 
     for data_dim, pca_dim, data in test_data:
         data_transformation = DataPCA.from_data(
             data=data, n_components=pca_dim
         )
-        transformed_data = data_transformation.transform(data)
 
-        assert transformed_data.shape[0] == n_samples
-        assert transformed_data.shape[1] == pca_dim
+        transformed_data = data_transformation.transform(data)
+        assert transformed_data.shape == (n_samples, pca_dim)
 
         transformed_datapoint = data_transformation.transform(data[0])
-        assert transformed_datapoint.shape == (1, pca_dim)
+        assert transformed_datapoint.shape == (pca_dim,)
 
         jacobian = data_transformation.jacobian(data[0])
         assert jacobian.shape == (pca_dim, data_dim)


### PR DESCRIPTION
# Description

Implements that DataPCA returns a 1d array if a 1d array was passed to the function.

Fixes #68 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please note/describe at least one tests that you ran to verify your changes.

- [x] Test: `test_DataPCA

## Checklist For Contributor

- [x] My code follows the style guidelines of this project (I installed pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I wrote my changes in the changelog in the `[unreleased]` section
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Checklist For Maintainers

- [ ] Continuous Integration (CI) is successfully running
- [x] Do we want to release/tag a new version? [❌]
