### PR TITLE
[Tests] Execute tutorial notebook in pytest suite

### DIFF
--- a/docs/source/tutorial_material/temperature.py
+++ b/docs/source/tutorial_material/temperature.py
@@ -1,0 +1,35 @@
+from typing import Optional
+
+import jax.numpy as jnp
+import numpy as np
+
+from eulerpi.core.model import Model
+
+
+class Temperature(Model):
+
+    param_dim = 1
+    data_dim = 1
+
+    PARAM_LIMITS = np.array([[0, np.pi / 2]])
+    CENTRAL_PARAM = np.array([np.pi / 4.0])
+
+    def __init__(
+        self,
+        central_param: np.ndarray = CENTRAL_PARAM,
+        param_limits: np.ndarray = PARAM_LIMITS,
+        name: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(central_param, param_limits, name=name, **kwargs)
+
+    def forward(self, param):
+        low_T = -30.0
+        high_T = 30.0
+        res = jnp.array(
+            [low_T + (high_T - low_T) * jnp.cos(jnp.abs(param[0]))]
+        )
+        return res
+
+    def jacobian(self, param):
+        return jnp.array([60.0 * jnp.sin(jnp.abs(param[0]))])

--- a/docs/source/tutorial_material/tutorial.ipynb
+++ b/docs/source/tutorial_material/tutorial.ipynb
@@ -129,9 +129,12 @@
    "outputs": [],
    "source": [
     "from typing import Optional\n",
-    "from eulerpi.core.model import Model\n",
-    "import numpy as np\n",
+    "\n",
     "import jax.numpy as jnp\n",
+    "import numpy as np\n",
+    "\n",
+    "from eulerpi.core.model import Model\n",
+    "\n",
     "\n",
     "class Temperature(Model):\n",
     "\n",
@@ -159,7 +162,7 @@
     "        return res\n",
     "\n",
     "    def jacobian(self, param):\n",
-    "        return jnp.array([60.0 * jnp.sin(jnp.abs(param[0]))])\n"
+    "        return jnp.array([60.0 * jnp.sin(jnp.abs(param[0]))])"
    ]
   },
   {

--- a/poetry.lock
+++ b/poetry.lock
@@ -1251,8 +1251,8 @@ importlib-metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 ml-dtypes = ">=0.2.0"
 numpy = [
     {version = ">=1.22", markers = "python_version < \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 opt-einsum = "*"
 scipy = [
@@ -2056,9 +2056,9 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">1.20", markers = "python_version < \"3.10\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
-    {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
     {version = ">=1.21.2", markers = "python_version >= \"3.10\" and python_version < \"3.11\""},
+    {version = ">=1.23.3", markers = "python_version >= \"3.11\" and python_version < \"3.12\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 
 [package.extras]
@@ -2135,25 +2135,24 @@ icu = ["PyICU (>=1.0.0)"]
 
 [[package]]
 name = "nbclient"
-version = "0.10.0"
+version = "0.6.8"
 description = "A client library for executing notebooks. Formerly nbconvert's ExecutePreprocessor."
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.7.0"
 files = [
-    {file = "nbclient-0.10.0-py3-none-any.whl", hash = "sha256:f13e3529332a1f1f81d82a53210322476a168bb7090a0289c795fe9cc11c9d3f"},
-    {file = "nbclient-0.10.0.tar.gz", hash = "sha256:4b3f1b7dba531e498449c4db4f53da339c91d449dc11e9af3a43b4eb5c5abb09"},
+    {file = "nbclient-0.6.8-py3-none-any.whl", hash = "sha256:7cce8b415888539180535953f80ea2385cdbb444944cdeb73ffac1556fdbc228"},
+    {file = "nbclient-0.6.8.tar.gz", hash = "sha256:268fde3457cafe1539e32eb1c6d796bbedb90b9e92bacd3e43d83413734bb0e8"},
 ]
 
 [package.dependencies]
-jupyter-client = ">=6.1.12"
-jupyter-core = ">=4.12,<5.0.dev0 || >=5.1.dev0"
-nbformat = ">=5.1"
-traitlets = ">=5.4"
+jupyter-client = ">=6.1.5"
+nbformat = ">=5.0"
+nest-asyncio = "*"
+traitlets = ">=5.2.2"
 
 [package.extras]
-dev = ["pre-commit"]
-docs = ["autodoc-traits", "mock", "moto", "myst-parser", "nbclient[test]", "sphinx (>=1.7)", "sphinx-book-theme", "sphinxcontrib-spelling"]
-test = ["flaky", "ipykernel (>=6.19.3)", "ipython", "ipywidgets", "nbconvert (>=7.0.0)", "pytest (>=7.0,<8)", "pytest-asyncio", "pytest-cov (>=4.0)", "testpath", "xmltodict"]
+sphinx = ["Sphinx (>=1.7)", "autodoc-traits", "mock", "moto", "myst-parser", "sphinx-book-theme"]
+test = ["black", "check-manifest", "flake8", "ipykernel", "ipython", "ipywidgets", "mypy", "nbconvert", "pip (>=18.1)", "pre-commit", "pytest (>=4.1)", "pytest-asyncio", "pytest-cov (>=2.6.1)", "setuptools (>=60.0)", "testpath", "twine (>=1.11.0)", "xmltodict"]
 
 [[package]]
 name = "nbconvert"
@@ -2213,6 +2212,24 @@ traitlets = ">=5.1"
 [package.extras]
 docs = ["myst-parser", "pydata-sphinx-theme", "sphinx", "sphinxcontrib-github-alt", "sphinxcontrib-spelling"]
 test = ["pep440", "pre-commit", "pytest", "testpath"]
+
+[[package]]
+name = "nbmake"
+version = "1.5.3"
+description = "Pytest plugin for testing notebooks"
+optional = false
+python-versions = ">=3.8.0,<4.0.0"
+files = [
+    {file = "nbmake-1.5.3-py3-none-any.whl", hash = "sha256:6cfa2b926d335e9c6dce7e8543d01b2398b0a56c03131c5c0bce2b1722116212"},
+    {file = "nbmake-1.5.3.tar.gz", hash = "sha256:0b76b829e8b128eb1895539bacf515a1ee85e5b7b492cdfe76e3a12f804e069e"},
+]
+
+[package.dependencies]
+ipykernel = ">=5.4.0"
+nbclient = ">=0.6.6,<0.7.0"
+nbformat = ">=5.0.8,<6.0.0"
+Pygments = ">=2.7.3,<3.0.0"
+pytest = ">=6.1.0"
 
 [[package]]
 name = "nest-asyncio"
@@ -2405,8 +2422,8 @@ files = [
 [package.dependencies]
 numpy = [
     {version = ">=1.22.4", markers = "python_version < \"3.11\""},
-    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
     {version = ">=1.23.2", markers = "python_version == \"3.11\""},
+    {version = ">=1.26.0", markers = "python_version >= \"3.12\""},
 ]
 python-dateutil = ">=2.8.2"
 pytz = ">=2020.1"
@@ -4075,4 +4092,4 @@ sbml = ["amici"]
 [metadata]
 lock-version = "2.0"
 python-versions = "<3.13, >=3.9"
-content-hash = "f1c7c59646d1f7ce0e35be534840046c37cd9796c8cfb76bd298ca4a18b2185d"
+content-hash = "ebdab6689addf78f1fcc436c33d2c108934f696c611a0f5716cc4ef7d26bd60c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ sphinx-togglebutton = "^0.3.2"
 sphinx-rtd-theme = "^1.3.0"
 myst-parser = "^2.0.0"
 jupyter = "^1.0.0"
+nbmake = "^1.5.3"
 
 [build-system]
 requires = ["poetry-core"]
@@ -70,6 +71,7 @@ per-file-ignores = ["__init__.py: F401"]
 [tool.pytest.ini_options]
 testpaths = [
   "tests",
+  "docs/source/tutorial_material",
 ]
 norecursedirs = [
     "generated_sbml_models",
@@ -79,6 +81,7 @@ norecursedirs = [
 ]
 addopts = [
     "--import-mode=importlib",
+    "--nbmake",
 ]
 pythonpath = ["eulerpi"]
 filterwarnings = [


### PR DESCRIPTION
# Description

Executes the tutorial notebook in the pytest suite, and therefore also in CI. Will prevent our tutorial from being in a broken state.

Fixes #113 

## Type of change

- [x] Internal Change

## How Has This Been Tested?

- [x] Local pytest run

## Checklist For Contributor

- [x] My code follows the style guidelines of this project (I installed pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote my changes in the changelog in the `[unreleased]` section
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Checklist For Maintainers

- [x] Continuous Integration (CI) is successfully running
- [x] Do we want to release/tag a new version? ❌
