### PR TITLE
[Tests] Switch from L1 to L2 error norm

### DIFF
--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -150,9 +150,12 @@ def test_inference_mcmc_dense_exact(
     mcmc_kde_error = np.abs(mcmc_kde - true_pdf_grid)
     dense_grid_pdf_error = np.abs(dense_grid_pdf - true_pdf_grid)
 
-    # Calculate the integrals of the errors
-    integral_mcmc_kde_error = integrate(to2d(mcmc_kde_error), x, y)
-    integral_dense_grid_pdf_error = integrate(to2d(dense_grid_pdf_error), x, y)
+    def l2_error(x, y, error):
+        return np.sqrt(integrate(to2d(error**2), x, y))
+
+    # Calculate the L2 error
+    integral_mcmc_kde_error = l2_error(x, y, mcmc_kde_error)
+    integral_dense_grid_pdf_error = l2_error(x, y, dense_grid_pdf_error)
 
     # Divide the integral through the area of the grid
     integral_mcmc_kde_error /= (lims[0, 1] - lims[0, 0]) * (
@@ -240,7 +243,7 @@ def test_inference_mcmc_dense_exact(
     # TODO: Then evaluate whether the threshold is set reasonable
     # TODO: The threshold should be adapted depending on how hard the problem is
     # and how many samples / grid points we have
-    threshold = 0.05
+    threshold = 0.02
     assert integral_mcmc_kde_error < threshold
     assert integral_dense_grid_pdf_error < threshold
 


### PR DESCRIPTION
# Description

Switching from L1 to L2 error norm for testing convergence of the inference function in the tests.
Setting a tighter limit to prevent regression.

Fixes #44 

## Type of change

- [x] Internal Change

## How Has This Been Tested?

- [x] Local pytest

## Checklist For Contributor

- [x] My code follows the style guidelines of this project (I installed pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote my changes in the changelog in the `[unreleased]` section
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Checklist For Maintainers

- [ ] Continuous Integration (CI) is successfully running
- [x] Do we want to release/tag a new version? [❌]
