### PR TITLE
[CI] Update amici to include upstream CI bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Raised required amici version to 0.26.1
+
 ### Fixed
 
 - Seed numpy random number generator for reproducibility of pytest runs

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,12 +13,12 @@ files = [
 
 [[package]]
 name = "amici"
-version = "0.25.1"
+version = "0.26.1"
 description = "Advanced multi-language Interface to CVODES and IDAS"
 optional = true
 python-versions = ">=3.10"
 files = [
-    {file = "amici-0.25.1.tar.gz", hash = "sha256:00a1b90a5abfc00fd9429a7690a5000d4966841345b6f0f88ffe11c604ebea02"},
+    {file = "amici-0.26.1.tar.gz", hash = "sha256:2dfc3e1a2941eb2f53eeef2175b00f9896223b987dbf8ae29f37e2cc8c3702dd"},
 ]
 
 [package.dependencies]
@@ -33,12 +33,12 @@ pandas = ">=2.0.2"
 pyarrow = "*"
 python-libsbml = "*"
 setuptools = ">=48"
-sympy = ">=1.9"
+sympy = ">=1.12.1"
 toposort = "*"
 
 [package.extras]
 examples = ["jupyter", "scipy"]
-petab = ["petab (>=0.2.9)"]
+petab = ["petab (>=0.4.0)"]
 pysb = ["pysb (>=1.13.1)"]
 test = ["antimony (!=2.14)", "antimony (>=2.13)", "coverage", "h5py", "pooch", "pytest", "pytest-cov", "pytest-rerunfailures", "scipy", "shyaml"]
 vis = ["matplotlib", "seaborn"]
@@ -4261,4 +4261,4 @@ sbml = ["amici"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10, <4.0"
-content-hash = "a4a0ca6e42ecbc8e4c231e45721a87d257b613dcc19be12cdb3a5a4fce1b8839"
+content-hash = "f7fa18a8249e018123a3d298cea26fd87653df5b075b466ffd1d5c7f25c93cf4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ emcee = ">=3.1.4"
 jaxlib = ">=0.4.19"
 tqdm = ">=4.66.1"
 seedir = ">=0.4.2"
-amici = { version = "^0.25.1", optional = true }
+amici = { version = ">=0.26.1", optional = true }
 scikit-learn = "^1.3.1"
 
 [tool.poetry.extras]


### PR DESCRIPTION
# Description

The CI pipeline is currently failing due to cmake errors in the build process of amici.
The errors occur because github updated the version of cmake from 0.29.x to 0.30.x in the ubuntu image. The cmake errors are fixed in amici version 0.26.1, and included with this pull request.

Note: There seems to be no way to fix the exact version of the runner image: https://github.com/actions/runner-images/issues/2894

## Type of change

Please tick at least one of the options. Delete the other options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Github Actions CI Pipeline

## Checklist For Contributor

- [x] My code follows the style guidelines of this project (I installed pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote my changes in the changelog in the `[unreleased]` section
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

## Checklist For Maintainers

- [x] Continuous Integration (CI) is successfully running
- [ ] Do we want to release/tag a new version? [✔️ / ❌]
  - [ ] If yes, add a release to the changelog and set the new version in pyproject.toml. After the merge, tag the release!
