### PR TITLE
Ignore sampler warnigns caused by paramters outside the parameter limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Raised required amici version to 0.26.1
+- Ignoring sampler warnings caused by parameters outside the parameter limits
 
 ### Fixed
 


### PR DESCRIPTION
# Description

EPI currently sets the log probability of a parameter point to `-inf` when the model is evaluated outside the parameter range limits. This leads to a large number of warning messages from the `emcee` mcmc sampler when a move leaves the parameter range. Warnings resulting from the subtraction of `-inf` in the `red_blue` move scheme are suppressed by this pull request. Other warning and error messages are not affected by this pull request.

## Type of change

Please tick at least one of the options. Delete the other options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Confirmed manually that the specific warning messages disappear and other warnings are unaffected

## Checklist For Contributor

- [x] My code follows the style guidelines of this project (I installed pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote my changes in the changelog in the `[unreleased]` section
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Checklist For Maintainers

- [x] Continuous Integration (CI) is successfully running
- [x] Do we want to release/tag a new version? [✔️ / ❌]
  - [x] If yes, add a release to the changelog and set the new version in pyproject.toml. After the merge, tag the release!
