### PR TITLE
Avoid warnings for jacobians close to zero in the corona model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+### Fixed
+
+## [0.9.1] - 2024-09-08
+
+### Changed
+
 - Raised required amici version to 0.26.1
 - Ignoring sampler warnings caused by parameters outside the parameter limits
 - Limited the parameter range and increased the solver accuracy of the Corona model to avoid warnings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 - Raised required amici version to 0.26.1
 - Ignoring sampler warnings caused by parameters outside the parameter limits
+- Limited the parameter range and increased the solver accuracy of the Corona model to avoid warnings
 
 ### Fixed
 

--- a/eulerpi/examples/corona/corona.py
+++ b/eulerpi/examples/corona/corona.py
@@ -39,7 +39,7 @@ class Corona(JaxModel):
     param_dim = 3
     data_dim = 4
 
-    PARAM_LIMITS = np.array([[-4.5, 0.5], [-2.0, 3.0], [-2.0, 3.0]])
+    PARAM_LIMITS = np.array([[-3.0, 0.0], [-2.0, 2.0], [-2.0, 2.0]])
     CENTRAL_PARAM = np.array([-1.8, 0.0, 0.7])
 
     def __init__(
@@ -69,7 +69,7 @@ class Corona(JaxModel):
         term = dx.ODETerm(rhs)
         solver = dx.Kvaerno5()
         saveat = dx.SaveAt(ts=[0.0, 1.0, 2.0, 5.0, 15.0])
-        stepsize_controller = dx.PIDController(rtol=1e-5, atol=1e-5)
+        stepsize_controller = dx.PIDController(rtol=1e-7, atol=1e-9)
 
         try:
             ode_sol = dx.diffeqsolve(
@@ -77,7 +77,7 @@ class Corona(JaxModel):
                 solver,
                 t0=0.0,
                 t1=15.0,
-                dt0=0.1,
+                dt0=0.01,
                 y0=xInit,
                 args=param,
                 saveat=saveat,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "eulerpi"
-version = "0.9.0"
+version = "0.9.1"
 description = "The eulerian parameter inference (eulerpi) returns a parameter distribution, which is consistent with the observed data by solving the inverse problem directly. In the case of a one-to-one mapping, this is the true underlying distribution."
 authors = ["Lars Kaiser <lars.g.kaiser@gmx.de>", "Sebastian Hoepfl <sebastian.hoepfl@ist.uni-stuttgart.de>", "Vincent Wagner <vincent.wagner@ist.uni-stuttgart.de>"]
 readme = "README.md"


### PR DESCRIPTION
# Description

The warning
```
The linear solver returned non-finite (NaN or inf) output. This usually means that the operator was not well-posed,
and that the solver does not support this. If you are trying solve a linear least-squares problem then you should pass
‘solver=AutoLinearSolver(well posed=False)‘. By default ‘lineax.linear solve‘ assumes that the operator is square
and nonsingular. If you *were* expecting this solver to work with this operator, then it may be because: (a) the operator
is singular, and your code has a bug; or (b) the operator was nearly singular (i.e. it had a high condition number:
‘jnp.linalg.cond(operator.as matrix())‘ is large), and the solver suffered from numerical instability issues; or (c) the
operator is declared to exhibit a certain property (e.g. positive definiteness) that is does not actually satisfy.
```
is generated by the package `diffrax` during the automatic differentiation of the ODE solution of the Corona model. It is generated when the Jacobian is close to zero, which leads to numerical problems. This pull request limits the parameter range of the Corona model and increases the solver accuracy to avoid this error. This change does not affect the inference quality, because the code treated these evaluations as a likelihood of 0 previously and the dropped parameter range is not essential to explain the data.\\

## Type of change

Please tick at least one of the options. Delete the other options.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist For Contributor

- [x] My code follows the style guidelines of this project (I installed pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I wrote my changes in the changelog in the `[unreleased]` section
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Checklist For Maintainers

- [x] Continuous Integration (CI) is successfully running
- [x] Do we want to release/tag a new version? [✔️ / ❌]
  - [x] If yes, add a release to the changelog and set the new version in pyproject.toml. After the merge, tag the release!
